### PR TITLE
Player favourites

### DIFF
--- a/src/app/auth/authentication.service.ts
+++ b/src/app/auth/authentication.service.ts
@@ -13,7 +13,11 @@ export class AuthenticationService {
   public user$: Observable<firebase.User> = this.afAuth.authState;
   public playerDoc: AngularFirestoreDocument<Player>;
   public player$: Observable<Player> = of(null);
-  constructor(private afAuth: AngularFireAuth, private afs: AngularFirestore) {
+
+  constructor(
+    private afAuth: AngularFireAuth,
+    private afs: AngularFirestore
+  ) {
 
     this.user$.subscribe(u => {
       if (!u) {
@@ -33,6 +37,7 @@ export class AuthenticationService {
         player.nickname = 'Player1';
         player.playerSince = now;
         player.lastLogin = now;
+        player.favouritePlayerIds = [];
         this.playerDoc.set(Object.assign({}, player));
       });
     });
@@ -46,6 +51,7 @@ export class AuthenticationService {
   login() {
     this.afAuth.auth.signInWithPopup(new auth.GoogleAuthProvider());
   }
+
   logout() {
     this.user = null;
     this.playerDoc = null;

--- a/src/app/domain/player.ts
+++ b/src/app/domain/player.ts
@@ -5,4 +5,5 @@ export class Player {
     lastLogin: Date;
     defaultTableRef: DocumentReference;
     playerSince: Date;
+    favouritePlayerIds: string[] = [];
 }

--- a/src/app/modules/tab1/components/player-select/player-select.component.html
+++ b/src/app/modules/tab1/components/player-select/player-select.component.html
@@ -21,11 +21,13 @@
     <div scrollY="true" id="scrollList">
       <ion-list>
         <ion-item *ngFor="let player of players$ | async | search : terms">
-          <ion-label>{{player.nickname}}</ion-label>
-          <ion-checkbox slot="start" mode="ios" [(ngModel)]="player.isSelected" (ionChange)="playerSelectionChanged(player)"
+          <ion-checkbox slot="start" mode="ios" [(ngModel)]="player.isSelected"
+            (ionChange)="playerSelectionChanged(player)"
             [disabled]="player.isOrganizer || ((isTeamFull$ | async) && !player.isSelected)"></ion-checkbox>
-          <ion-toggle slot="end" mode="ios" [(ngModel)]="player.isFavourite" (ionChange)="playerFavouriteChanged(player)"
-            [disabled]="player.isOrganizer"></ion-toggle>
+          <ion-label>{{player.nickname}}</ion-label>
+          <ion-icon class="favourite" slot="end" [name]="player.isFavourite ? 'star' :'star-outline'"
+            (click)="playerFavouriteChanged(player)">
+          </ion-icon>
         </ion-item>
       </ion-list>
     </div>

--- a/src/app/modules/tab1/components/player-select/player-select.component.html
+++ b/src/app/modules/tab1/components/player-select/player-select.component.html
@@ -22,8 +22,10 @@
       <ion-list>
         <ion-item *ngFor="let player of players$ | async | search : terms">
           <ion-label>{{player.nickname}}</ion-label>
-          <ion-checkbox slot="start" mode="ios" [(ngModel)]="player.isSelected" (ionChange)="checkboxChanged(player)"
+          <ion-checkbox slot="start" mode="ios" [(ngModel)]="player.isSelected" (ionChange)="playerSelectionChanged(player)"
             [disabled]="player.isOrganizer || ((isTeamFull$ | async) && !player.isSelected)"></ion-checkbox>
+          <ion-toggle slot="end" mode="ios" [(ngModel)]="player.isFavourite" (ionChange)="playerFavouriteChanged(player)"
+            [disabled]="player.isOrganizer"></ion-toggle>
         </ion-item>
       </ion-list>
     </div>

--- a/src/app/modules/tab1/components/player-select/player-select.component.scss
+++ b/src/app/modules/tab1/components/player-select/player-select.component.scss
@@ -28,3 +28,9 @@ div[scrolly=true] {
     flex-grow:0;
     flex-shrink: 0;
 }
+
+.favourite {
+    color: orange;
+    cursor: pointer;
+    z-index: 2;
+}

--- a/src/app/modules/tab1/components/player-select/player-select.component.ts
+++ b/src/app/modules/tab1/components/player-select/player-select.component.ts
@@ -15,7 +15,7 @@ import { PlayerService } from 'src/app/services/player.service';
 })
 export class PlayerSelectComponent implements OnInit {
   public players: AngularFirestoreCollection<Player>;
-  public players$: Observable<any>;
+  public players$: Observable<PlayerSelectModel[]>;
   public selectedTeam: Team = Team.teamA;
   public selectedTeam$: BehaviorSubject<Team>;
   public isTeamFull$: Observable<boolean>;

--- a/src/app/modules/tab1/components/player-select/player-select.component.ts
+++ b/src/app/modules/tab1/components/player-select/player-select.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { AngularFirestore, AngularFirestoreCollection, AngularFirestoreDocument } from '@angular/fire/firestore';
 import { Player, Team, Match } from '../../../../domain';
 import { Observable, combineLatest, BehaviorSubject } from 'rxjs';
-import { map, withLatestFrom } from 'rxjs/operators';
+import { map, withLatestFrom, tap } from 'rxjs/operators';
 import { PlayerSelectModel } from './player-select.model';
 import { ModalController } from '@ionic/angular';
 import { MatchService } from 'src/app/services/match.service';
@@ -90,6 +90,12 @@ export class PlayerSelectComponent implements OnInit {
   }
 
   public playerFavouriteChanged(player: PlayerSelectModel) {
+    if (player.isOrganizer) {
+      return;
+    }
+
+    player.isFavourite = !player.isFavourite;
+
     if (player.isFavourite) {
       this.playerService.addPlayerToFavourites(player.id);
     } else {

--- a/src/app/modules/tab1/components/player-select/player-select.component.ts
+++ b/src/app/modules/tab1/components/player-select/player-select.component.ts
@@ -6,6 +6,7 @@ import { map, withLatestFrom } from 'rxjs/operators';
 import { PlayerSelectModel } from './player-select.model';
 import { ModalController } from '@ionic/angular';
 import { MatchService } from 'src/app/services/match.service';
+import { PlayerService } from 'src/app/services/player.service';
 
 @Component({
   selector: 'app-player-select',
@@ -14,15 +15,19 @@ import { MatchService } from 'src/app/services/match.service';
 })
 export class PlayerSelectComponent implements OnInit {
   public players: AngularFirestoreCollection<Player>;
-  public players$: Observable<PlayerSelectModel[]>;
+  public players$: Observable<any>;
   public selectedTeam: Team = Team.teamA;
   public selectedTeam$: BehaviorSubject<Team>;
   public isTeamFull$: Observable<boolean>;
   public terms = '';
   private matchDoc: AngularFirestoreDocument<Match>;
-  constructor(private matchService: MatchService,
+
+  constructor(
+    private matchService: MatchService,
+    private playerService: PlayerService,
     private afs: AngularFirestore,
     private modalController: ModalController) { }
+
   ngOnInit() {
     this.matchDoc = this.matchService.currentMatchDocument;
     this.selectedTeam$ = new BehaviorSubject(0);
@@ -32,48 +37,84 @@ export class PlayerSelectComponent implements OnInit {
         if (!match) { return true; }
         return team === Team.teamA ? match.teamA.length === 2 : match.teamB.length === 2;
       }));
+
     this.players = this.afs.collection<Player>('players');
     const playerChanges = this.players.snapshotChanges();
-    this.players$ = combineLatest(playerChanges, this.selectedTeam$)
-      .pipe(withLatestFrom(this.matchDoc.valueChanges()))
-      .pipe(map(ps => {
-        const playerDocs = ps[0][0]; const team = ps[0][1]; const match = ps[1];
-        return playerDocs
-          .map(p => {
-            const playerDoc = p.payload.doc;
-            const playerSelectModel = new PlayerSelectModel();
-            playerSelectModel.id = playerDoc.id;
-            playerSelectModel.nickname = playerDoc.data().nickname;
-            playerSelectModel.isSelected = this.isInSelectedTeam(playerDoc.id, team, match);
-            playerSelectModel.isOrganizer = playerDoc.id === match.organizer;
-            return playerSelectModel;
-          })
-          .filter(p => this.isNotInOtherTeam(p, team, match))
-          .sort(this.sortPlayers);
-      }));
+
+    this.players$ =
+      combineLatest(
+        playerChanges,
+        this.selectedTeam$,
+        this.playerService.getFavourites()
+      ).pipe(
+        withLatestFrom(
+          this.matchDoc.valueChanges()
+        )
+      ).pipe(
+        map(ps => {
+          const playerDocs = ps[0][0];
+          const team = ps[0][1];
+          const playerFavourites = ps[0][2];
+          const match = ps[1];
+
+          return playerDocs
+            .map((p) => {
+              const playerDoc = p.payload.doc;
+              const playerSelectModel = new PlayerSelectModel();
+              playerSelectModel.id = playerDoc.id;
+              playerSelectModel.nickname = playerDoc.data().nickname;
+              playerSelectModel.isSelected = this.isInSelectedTeam(playerDoc.id, team, match);
+              playerSelectModel.isOrganizer = playerDoc.id === match.organizer;
+              playerSelectModel.isFavourite = playerFavourites && playerFavourites
+                .some((favouriteId: string) => favouriteId === playerDoc.id);
+
+              return playerSelectModel;
+            })
+            .filter(p => this.isNotInOtherTeam(p, team, match))
+            .sort(this.sortPlayers);
+        })
+      );
   }
+
   public selectedTeamChanged($event: CustomEvent) {
     this.selectedTeam = $event.detail.value as Team;
     this.selectedTeam$.next(Number($event.detail.value));
   }
-  public checkboxChanged(player: PlayerSelectModel) {
+
+  public playerSelectionChanged(player: PlayerSelectModel) {
     if (player.isSelected) {
       this.matchService.addTeamPlayerToMatch(player.id, Number(this.selectedTeam));
     } else {
       this.matchService.removeTeamPlayerFromMatch(player.id);
     }
   }
+
+  public playerFavouriteChanged(player: PlayerSelectModel) {
+    if (player.isFavourite) {
+      this.playerService.addPlayerToFavourites(player.id);
+    } else {
+      this.playerService.removePlayerFromFavourites(player.id);
+    }
+  }
+
   public dismiss(): void {
     this.modalController.dismiss();
   }
+
   private isInSelectedTeam(playerId: string, team: Team, match: Match): boolean {
     return team === Team.teamA ? match.teamA.map(p => p.playerRef.id).indexOf(playerId) >= 0
       : match.teamB.map(p => p.playerRef.id).indexOf(playerId) >= 0;
   }
+
   private sortPlayers(a: PlayerSelectModel, b: PlayerSelectModel): number {
-    return b.isSelected === a.isSelected ? Number(b.isOrganizer) - Number(a.isOrganizer)
-      : Number(b.isSelected) - Number(a.isSelected);
+    const aScore = (a.isOrganizer ? 1 : 0) + (a.isSelected ? 1 : 0) + (a.isFavourite ? 1 : 0);
+    const bScore = (b.isOrganizer ? 1 : 0) + (b.isSelected ? 1 : 0) + (b.isFavourite ? 1 : 0);
+
+    return bScore === aScore ?
+      (b.nickname <= a.nickname ? 1 : 0) :
+      bScore - aScore;
   }
+
   private isNotInOtherTeam(player: PlayerSelectModel, team: Team, match: Match): boolean {
     return team === Team.teamA ? match.teamB.map(p => p.playerRef.id).indexOf(player.id) === -1
       : match.teamA.map(p => p.playerRef.id).indexOf(player.id) === -1;

--- a/src/app/modules/tab1/components/player-select/player-select.model.ts
+++ b/src/app/modules/tab1/components/player-select/player-select.model.ts
@@ -1,6 +1,7 @@
 export class PlayerSelectModel {
     public id: string;
     public isSelected: boolean;
+    public isFavourite: boolean;
     public nickname: string;
     public isOrganizer: boolean;
 }

--- a/src/app/modules/tab1/tab1.page.ts
+++ b/src/app/modules/tab1/tab1.page.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { AuthenticationService } from '../../auth/authentication.service';
-import { Router } from '@angular/router';
 import { Team, Player } from '../../domain';
 import { ToastController } from '@ionic/angular';
 import { MatchService } from '../../services/match.service';
@@ -15,7 +14,9 @@ import { PlayerSelectComponent } from './components/player-select/player-select.
 export class Tab1Page {
   public isInEditMode = false;
   public gamePin?: number = null;
-  constructor(public authService: AuthenticationService,
+
+  constructor(
+    public authService: AuthenticationService,
     private matchService: MatchService,
     private toastController: ToastController,
     private modalController: ModalController) {
@@ -24,42 +25,54 @@ export class Tab1Page {
   public async createMatch(player: Player) {
     this.matchService.createMatch(player);
   }
+
   public async addPlayers() {
     const modal = await this.modalController.create({
       component: PlayerSelectComponent
     });
     return await modal.present();
   }
+
   public async startMatch() {
     await this.matchService.startMatch();
   }
+
   public async cancelMatch() {
     await this.matchService.cancelMatch();
   }
+
   public async finishMatch() {
     await this.matchService.finishMatch();
   }
+
   public async onScored($event: { goalsTeamA: number, goalsTeamB: number }) {
     await this.matchService.onScored($event);
   }
+
   public async onScoringCancelled() {
     await this.matchService.onScoringCancelled();
   }
+
   public async onMatchJoined($event: Team) {
     await this.matchService.onMatchJoined(this.authService.playerDoc.ref, $event);
   }
+
   public async leaveTeam() {
     await this.matchService.leaveMatch(this.authService.playerDoc.ref);
   }
+
   public async leaveMatch() {
     await this.matchService.leaveMatch(this.authService.playerDoc.ref);
   }
+
   public async dismissMatch() {
     await this.matchService.dismissMatch();
   }
+
   public startEditMode(): void {
     this.isInEditMode = true;
   }
+
   public async findMatchToJoin() {
     if (!this.gamePin) { return; }
     await this.matchService.findMatchToJoin(this.gamePin, async () => {

--- a/src/app/services/player.service.spec.ts
+++ b/src/app/services/player.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PlayerService } from './player.service';
+
+describe('PlayerService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: PlayerService = TestBed.get(PlayerService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/player.service.ts
+++ b/src/app/services/player.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { AuthenticationService } from '../auth/authentication.service';
 import { firestore } from 'firebase';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { map, tap } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'

--- a/src/app/services/player.service.ts
+++ b/src/app/services/player.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@angular/core';
+import { AuthenticationService } from '../auth/authentication.service';
+import { firestore } from 'firebase';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PlayerService {
+
+  constructor(
+    public authService: AuthenticationService
+  ) { }
+
+  public async addPlayerToFavourites(playerId: string): Promise<void> {
+    const playerDocRef = this.authService.playerDoc.ref;
+
+    const payload: firestore.UpdateData = {
+      favouritePlayerIds: firestore.FieldValue.arrayUnion(playerId),
+    };
+
+    await playerDocRef.update(payload);
+  }
+
+  public async removePlayerFromFavourites(playerId: string): Promise<void> {
+    const playerDocRef = this.authService.playerDoc.ref;
+
+    const payload: firestore.UpdateData = {
+      favouritePlayerIds: firestore.FieldValue.arrayRemove(playerId),
+    };
+
+    await playerDocRef.update(payload);
+  }
+
+  public getFavourites(): Observable<string[]> {
+    return this.authService.playerDoc.valueChanges().pipe(
+      map(player => player.favouritePlayerIds)
+    );
+  }
+}


### PR DESCRIPTION
A suggested implementation for marking players as favourite.

Questions:
- We don't really have a player management place. Since the match player selection window is currently the only place where favourites are useful I have implemented it there.
- I would rather have an empty / yellow star toggle to indicate favourite players, but I could not yet find the "right" way to do that in ionic. Before I dug deeper I wanted to check if that would indeed be a better UI.
- I think nick name assigning should probably also be moved to the new `PlayerService` but I did not want to move too much in 1 PR.
- I never did any Firebase stuff before, is this indeed the right way to update an array property?

I have also updated player sorting based on organizer + selected + favourite + nickname.